### PR TITLE
fix: relative path for links

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Parameters:
 - `params.entries`: The entries of the documentation (functions, constants and classes).
 - `params.options`: Optional configuration to render the Markdown content. See `types.ts` for details.
 
-[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main//home/runner/work/tsdoc-markdown/tsdoc-markdown/src/lib/markdown.ts#L221)
+[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/markdown.ts#L230)
 
 ### :gear: generateDocumentation
 

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,4 +1,4 @@
-import {resolve} from 'path';
+import {relative, resolve} from 'path';
 import type {
   ArrowFunction,
   CompilerOptions,
@@ -245,11 +245,13 @@ export const buildDocumentation = ({
     forEachChild(sourceFile, (node: Node) => {
       const entries: DocEntry[] = visit({checker, node});
       const {line} = sourceFile.getLineAndCharacterOfPosition(node.getStart());
+      const filePath = relative(process.cwd(), sourceFile.fileName);
+
       result.push(
         ...entries.map((entry: DocEntry) => ({
           ...entry,
           line: line + 1,
-          fileName: sourceFile.fileName
+          fileRelativePath: filePath
         }))
       );
     });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,7 +8,7 @@ export type DocEntryConstructor = Pick<DocEntry, 'parameters' | 'returnType' | '
 
 export interface DocEntry {
   name: string;
-  fileName?: string;
+  fileRelativePath?: string;
   documentation?: string;
   type?: string;
   constructors?: DocEntryConstructor[];


### PR DESCRIPTION
When I incoporated the lib in [ic-js](https://github.com/dfinity/ic-js) and run a CI build, I noticed some paths for links were absolute.

https://github.com/dfinity/ic-js/pull/374/files#diff-fe99193c708bc3807bec69f753f00016179e5815584955cac2d96b100f174730