### PR TITLE
feat: generate links to json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,14 @@
     "project": ["./tsconfig.json"]
   },
   "plugins": ["@typescript-eslint"],
-  "ignorePatterns": ["**/dist/", "jest.config.js", "**/*.spec.ts", "**/*.test.ts", "**/mock.ts", "bin/index.js"],
+  "ignorePatterns": [
+    "**/dist/",
+    "jest.config.js",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/mock.ts",
+    "bin/index.js"
+  ],
   "rules": {
     "@typescript-eslint/consistent-type-imports": "error"
   }

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Parameters:
 - `params.inputFiles`: The list of files to scan and for which the documentation should be build.
 - `params.options`: Optional compiler options to generate the docs
 
-[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/docs.ts#L212)
+[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/docs.ts#L213)
 
 ### :gear: documentationToMarkdown
 
@@ -138,7 +138,7 @@ Parameters:
 - `params.entries`: The entries of the documentation (functions, constants and classes).
 - `params.options`: Optional configuration to render the Markdown content. See `types.ts` for details.
 
-[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/markdown.ts#L230)
+[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/markdown.ts#L211)
 
 ### :gear: generateDocumentation
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ const utilsInputFiles = ['./packages/utils/src/index.ts'];
 generateDocumentation({
   inputFiles: utilsInputFiles,
   outputFile: './packages/utils/YOLO.md',
-  buildOptions: {explore: true},
-  markdownOptions: {
+  buildOptions: {
+    explore: true,
     repo: {
       url: 'https://github.com/peterpeterparker/tsdoc-markdown'
     }

--- a/bin/index.js
+++ b/bin/index.js
@@ -45,7 +45,7 @@ generateDocumentation({
   inputFiles,
   outputFile,
   ...(repoUrl !== undefined && {
-    markdownOptions: {
+    buildOptions: {
       repo: {
         url: repoUrl
       }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,7 +8,8 @@ export type DocEntryConstructor = Pick<DocEntry, 'parameters' | 'returnType' | '
 
 export interface DocEntry {
   name: string;
-  fileRelativePath?: string;
+  fileName?: string;
+  url?: string;
   documentation?: string;
   type?: string;
   constructors?: DocEntryConstructor[];
@@ -17,13 +18,6 @@ export interface DocEntry {
   returnType?: string;
   jsDocs?: JSDocTagInfo[];
   doc_type?: DocEntryType;
-  line?: number;
-}
-
-export interface MarkdownRepo {
-  url: string;
-  // Default: "main" branch
-  branch?: string;
 }
 
 /**
@@ -49,8 +43,12 @@ export interface MarkdownOptions {
   emoji?: MarkdownEmoji | null;
   // The base heading level at which the documentation should start. Default ##
   headingLevel?: MarkdownHeadingLevel;
-  // If provided, the Markdown parser will generate links to the documented source code
-  repo?: MarkdownRepo;
+}
+
+export interface RepoOptions {
+  url: string;
+  // Default: "main" branch
+  branch?: string;
 }
 
 /**
@@ -60,5 +58,7 @@ export interface BuildOptions {
   // The compiler options use to create the TypeScript program
   compilerOptions?: CompilerOptions;
   // `false` per default to limit the scope of the documentation to the input files only. If turns to `true`, all files of the program will be analyzed to generate the documentation.
-  explore: boolean;
+  explore?: boolean;
+  // If provided, the Markdown parser will generate links to the documented source code
+  repo?: RepoOptions;
 }

--- a/src/test/docs.spec.ts
+++ b/src/test/docs.spec.ts
@@ -10,4 +10,21 @@ describe('docs', () => {
     const expectedDoc = readFileSync('./src/test/mock.json', 'utf8');
     expect(doc).toEqual(JSON.parse(expectedDoc));
   });
+
+  it('should generate json with links to source code', () => {
+    const doc = buildDocumentation({
+      inputFiles: ['./src/test/mock.ts'],
+      options: {
+        repo: {
+          url: 'https://github.com/peterpeterparker/tsdoc-markdown/'
+        }
+      }
+    });
+
+    const expectedDoc = readFileSync('./src/test/mock.json', 'utf8');
+    expect(doc[0]).toEqual({
+      ...JSON.parse(expectedDoc)[0],
+      url: 'https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L6'
+    });
+  });
 });

--- a/src/test/markdown.spec.ts
+++ b/src/test/markdown.spec.ts
@@ -5,16 +5,16 @@ import {buildDocumentation} from '../lib/docs';
 describe('markdown', () => {
   it('should generate markdown for mock', () => {
     const doc = buildDocumentation({
-      inputFiles: ['./src/test/mock.ts']
-    });
-
-    const markdown: string = documentationToMarkdown({
-      entries: doc,
+      inputFiles: ['./src/test/mock.ts'],
       options: {
         repo: {
           url: 'https://github.com/peterpeterparker/tsdoc-markdown'
         }
       }
+    });
+
+    const markdown: string = documentationToMarkdown({
+      entries: doc
     });
 
     const expectedDoc = readFileSync('./src/test/mock.md', 'utf8');
@@ -24,16 +24,16 @@ describe('markdown', () => {
 
   it.each([35, 86, 114])('should generate a markdown link to line %s', (line) => {
     const doc = buildDocumentation({
-      inputFiles: ['./src/test/mock.ts']
-    });
-
-    const markdown: string = documentationToMarkdown({
-      entries: doc,
+      inputFiles: ['./src/test/mock.ts'],
       options: {
         repo: {
           url: 'https://github.com/peterpeterparker/tsdoc-markdown/'
         }
       }
+    });
+
+    const markdown: string = documentationToMarkdown({
+      entries: doc
     });
 
     expect(markdown).toContain(

--- a/src/test/mock.json
+++ b/src/test/mock.json
@@ -20,7 +20,6 @@
       }
     ],
     "name": "hello",
-    "line": 6,
     "type": "(world: string) => string"
   },
   {
@@ -28,7 +27,6 @@
     "documentation": "A constant",
     "fileName": "src/test/mock.ts",
     "jsDocs": [],
-    "line": 11,
     "name": "numberOne",
     "type": "2"
   },
@@ -37,7 +35,6 @@
     "documentation": "hello2",
     "fileName": "src/test/mock.ts",
     "jsDocs": [],
-    "line": 16,
     "name": "hello2",
     "type": "() => void"
   },
@@ -46,7 +43,6 @@
     "documentation": "Markdown should handle ` | ` for the type.",
     "fileName": "src/test/mock.ts",
     "jsDocs": [],
-    "line": 23,
     "name": "genericType",
     "type": "<T>(value: [] | [T]) => T"
   },
@@ -97,7 +93,6 @@
     "documentation": "LedgerCanister is a test class.",
     "fileName": "src/test/mock.ts",
     "jsDocs": [],
-    "line": 35,
     "methods": [
       {
         "doc_type": "method",
@@ -141,7 +136,6 @@
     "documentation": "",
     "fileName": "src/test/mock.ts",
     "jsDocs": [],
-    "line": 86,
     "methods": [
       {
         "doc_type": "method",
@@ -177,7 +171,6 @@
     "documentation": "",
     "fileName": "src/test/mock.ts",
     "jsDocs": [],
-    "line": 114,
     "methods": [
       {
         "doc_type": "method",


### PR DESCRIPTION
It can be handy to not only parse the URL to source code in the markdown code but, also to have the information within the json object that is generated by `buildDocumentation`.