### PR TITLE
fix: support for const that contains arrow functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Parameters:
 - `params.inputFiles`: The list of files to scan and for which the documentation should be build.
 - `params.options`: Optional compiler options to generate the docs
 
-[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/docs.ts#L481)
+[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/docs.ts#L482)
 
 ### :gear: documentationToMarkdown
 

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -347,25 +347,26 @@ const visit = ({
   } else {
     const arrowFunc: Node | undefined = findDescendantArrowFunction(node);
 
-    if (arrowFunc !== undefined) {
-      const symbol = checker.getSymbolAtLocation(
-        ((arrowFunc as ArrowFunction).parent as VariableDeclaration).name
-      );
+    const arrowFuncSymbol =
+      arrowFunc !== undefined
+        ? checker.getSymbolAtLocation(
+            ((arrowFunc as ArrowFunction).parent as VariableDeclaration).name
+          )
+        : undefined;
 
-      if (symbol !== undefined) {
-        const parentName = !isRootOrClassLevelArrowFunction(arrowFunc)
-          ? getRootParentName(arrowFunc)
-          : undefined;
+    if (arrowFunc !== undefined && arrowFuncSymbol !== undefined) {
+      const parentName = !isRootOrClassLevelArrowFunction(arrowFunc)
+        ? getRootParentName(arrowFunc)
+        : undefined;
 
-        const details = serializeSymbol({checker, symbol, doc_type: 'function'});
-        pushEntry({
-          node,
-          details: {
-            ...details,
-            name: parentName !== undefined ? `${parentName}.${details.name}` : details.name
-          }
-        });
-      }
+      const details = serializeSymbol({checker, symbol: arrowFuncSymbol, doc_type: 'function'});
+      pushEntry({
+        node,
+        details: {
+          ...details,
+          name: parentName !== undefined ? `${parentName}.${details.name}` : details.name
+        }
+      });
     } else if (isPropertyDeclaration(node)) {
       // We test for the property after the arrow function because a public property of a class can be an arrow function.
       const symbol = checker.getSymbolAtLocation(node.name);

--- a/src/test/mock.json
+++ b/src/test/mock.json
@@ -482,5 +482,23 @@
     "jsDocs": [],
     "doc_type": "function",
     "fileName": "src/test/mock.ts"
+  },
+  {
+    "name": "PrincipalTextSchema",
+    "documentation": "Zod schema to validate a string as a valid textual representation of a Principal.\n\nThis schema checks if the provided string can be converted into a `Principal` instance.\nIf the conversion fails, validation will return an error message.",
+    "type": "any",
+    "jsDocs": [
+      {
+        "name": "example",
+        "text": [
+          {
+            "text": "```typescript\nconst result = PrincipalTextSchema.safeParse('aaaaa-aa');\nconsole.log(result.success); // true or false\n```",
+            "kind": "text"
+          }
+        ]
+      }
+    ],
+    "doc_type": "const",
+    "fileName": "src/test/mock.ts"
   }
 ]

--- a/src/test/mock.md
+++ b/src/test/mock.md
@@ -101,6 +101,7 @@ function submit() {
 ## :wrench: Constants
 
 - [numberOne](#gear-numberone)
+- [PrincipalTextSchema](#gear-principaltextschema)
 
 ### :gear: numberOne
 
@@ -111,6 +112,27 @@ A constant
 | `numberOne` | `2` |
 
 [:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L11)
+
+### :gear: PrincipalTextSchema
+
+Zod schema to validate a string as a valid textual representation of a Principal.
+
+This schema checks if the provided string can be converted into a `Principal` instance.
+If the conversion fails, validation will return an error message.
+
+| Constant | Type |
+| ---------- | ---------- |
+| `PrincipalTextSchema` | `any` |
+
+Examples:
+
+```typescript
+const result = PrincipalTextSchema.safeParse('aaaaa-aa');
+console.log(result.success); // true or false
+```
+
+
+[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L298)
 
 
 ## :factory: LedgerCanister

--- a/src/test/mock.ts
+++ b/src/test/mock.ts
@@ -282,3 +282,29 @@ export const MyObject = {
   someField: 'foo',
   someFunction: () => {}
 };
+
+/**
+ * Zod schema to validate a string as a valid textual representation of a Principal.
+ *
+ * This schema checks if the provided string can be converted into a `Principal` instance.
+ * If the conversion fails, validation will return an error message.
+ *
+ * @example
+ * ```typescript
+ * const result = PrincipalTextSchema.safeParse('aaaaa-aa');
+ * console.log(result.success); // true or false
+ * ```
+ */
+export const PrincipalTextSchema = z.string().refine(
+  (principal) => {
+    try {
+      Principal.fromText(principal);
+      return true;
+    } catch (err: unknown) {
+      return false;
+    }
+  },
+  {
+    message: 'Invalid textual representation of a Principal.'
+  }
+);


### PR DESCRIPTION
The parser could not generate documentation for the Zod schema because it attempted to document the inner refine function and did not continue traversing the node when no documentation was found.