### PR TITLE
chore: fix ubuntu runner

### DIFF
--- a/.github/workflows/tsdoc.yml
+++ b/.github/workflows/tsdoc.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Runner Ubuntu 20.04 is deprecated.