### PR TITLE
feat: markdown formatting (spacing) for @returns support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Parameters:
 - `params.options`: Optional compiler options to generate the docs
 
 Returns:
+
 An array of documentation entries
 
 [:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/docs.ts#L496)
@@ -167,7 +168,7 @@ Parameters:
 - `params.entries`: The entries of the documentation (functions, constants and classes).
 - `params.options`: Optional configuration to render the Markdown content. See `types.ts` for details.
 
-[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/markdown.ts#L360)
+[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/markdown.ts#L361)
 
 ### :gear: generateDocumentation
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -298,8 +298,9 @@ const toMarkdown = ({
       markdown.push(...inlineParams(params));
       markdown.push('\n');
     }
-    if (returnType) {
-      markdown.push(`Returns:\n\t${returnType}\n`);
+    if (returnType !== undefined && returnType !== '') {
+      markdown.push(`Returns:\n`);
+      markdown.push(`${returnType}\n`);
     }
     if (examples.length) {
       markdown.push('Examples:\n');

--- a/src/test/mock.md
+++ b/src/test/mock.md
@@ -180,7 +180,8 @@ Returns the balance of the specified account identifier.
 | `accountBalance` | `({ certified }: { certified?: boolean or undefined; }) => Promise<{ icp: bigint; }>` |
 
 Returns:
-	The balance of the specified account identifier
+
+The balance of the specified account identifier
 
 [:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L70)
 


### PR DESCRIPTION
Follow-up of #61. A bit opiniated but, after running a test over [github.com/dfinity/ic-js/](https://github.com/dfinity/ic-js/).  I felt like a bit of spacing and no indentation fit better the current markdown layout if there are few information.