### PR TITLE
feat: support for @see to render list of references

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Parameters:
 - `params.entries`: The entries of the documentation (functions, constants and classes).
 - `params.options`: Optional configuration to render the Markdown content. See `types.ts` for details.
 
-[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/markdown.ts#L361)
+[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/markdown.ts#L365)
 
 ### :gear: generateDocumentation
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Parameters:
 - `params.entries`: The entries of the documentation (functions, constants and classes).
 - `params.options`: Optional configuration to render the Markdown content. See `types.ts` for details.
 
-[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/markdown.ts#L365)
+[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/markdown.ts#L418)
 
 ### :gear: generateDocumentation
 

--- a/src/test/mock.json
+++ b/src/test/mock.json
@@ -559,5 +559,90 @@
       }
     ],
     "fileName": "src/test/mock.ts"
+  },
+  {
+    "name": "SOMETHING",
+    "documentation": "A constant",
+    "type": "\"abc\"",
+    "jsDocs": [
+      {
+        "name": "see",
+        "text": [
+          {
+            "text": "hello2",
+            "kind": "text"
+          },
+          {
+            "text": " ",
+            "kind": "space"
+          },
+          {
+            "text": "*",
+            "kind": "text"
+          }
+        ]
+      },
+      {
+        "name": "see",
+        "text": [
+          {
+            "text": "https",
+            "kind": "text"
+          },
+          {
+            "text": "://daviddalbusco.com",
+            "kind": "text"
+          }
+        ]
+      },
+      {
+        "name": "see",
+        "text": [
+          {
+            "text": "",
+            "kind": "text"
+          },
+          {
+            "text": "{@link ",
+            "kind": "link"
+          },
+          {
+            "text": "hello ",
+            "kind": "linkText"
+          },
+          {
+            "text": "}",
+            "kind": "link"
+          },
+          {
+            "text": " – Another related function",
+            "kind": "text"
+          }
+        ]
+      },
+      {
+        "name": "see",
+        "text": [
+          {
+            "text": "",
+            "kind": "text"
+          },
+          {
+            "text": "{@link ",
+            "kind": "link"
+          },
+          {
+            "text": "https://github.com/peterpeterparker/tsdoc-markdown Source code",
+            "kind": "linkText"
+          },
+          {
+            "text": "}",
+            "kind": "link"
+          }
+        ]
+      }
+    ],
+    "doc_type": "const",
+    "fileName": "src/test/mock.ts"
   }
 ]

--- a/src/test/mock.md
+++ b/src/test/mock.md
@@ -102,6 +102,7 @@ function submit() {
 
 - [numberOne](#gear-numberone)
 - [PrincipalTextSchema](#gear-principaltextschema)
+- [SOMETHING](#gear-something)
 
 ### :gear: numberOne
 
@@ -133,6 +134,16 @@ console.log(result.success); // true or false
 
 
 [:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L299)
+
+### :gear: SOMETHING
+
+A constant
+
+| Constant | Type |
+| ---------- | ---------- |
+| `SOMETHING` | `"abc"` |
+
+[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L338)
 
 
 ## :factory: LedgerCanister

--- a/src/test/mock.md
+++ b/src/test/mock.md
@@ -143,6 +143,14 @@ A constant
 | ---------- | ---------- |
 | `SOMETHING` | `"abc"` |
 
+References:
+
+* hello2
+* [https://daviddalbusco.com](https://daviddalbusco.com)
+* `hello`
+* [Source code](https://github.com/peterpeterparker/tsdoc-markdown)
+
+
 [:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L338)
 
 

--- a/src/test/mock.ts
+++ b/src/test/mock.ts
@@ -327,3 +327,12 @@ export class Number {
     return new Number(n1.value + n2.value);
   }
 }
+
+/**
+ * A constant
+ * @see hello2
+ * @see https://daviddalbusco.com
+ * @see {@link hello} – Another related function
+ * @see {@link https://github.com/peterpeterparker/tsdoc-markdown | Source code}
+ */
+export const SOMETHING = 'abc';


### PR DESCRIPTION
Renders list of references provided by `@see`:

e.g.

> References:
>
>* hello2
>* [https://daviddalbusco.com](https://daviddalbusco.com)
>* `hello`
>* [Source code](https://github.com/peterpeterparker/tsdoc-markdown)