### PR TITLE
Add option to skip code elements with @internal jsDoc tag

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -13,6 +13,7 @@ if (help !== undefined) {
   console.log('--dest=<destination file> (default README.md)');
   console.log('--repo=<GitHub repo URL>');
   console.log('--types');
+  console.log('--skipInternal');
   console.log('--noemoji');
   return;
 }
@@ -41,6 +42,8 @@ const repoUrl = process.argv.find((arg) => arg.indexOf('--repo=') > -1)?.replace
 
 const types = process.argv.find((arg) => arg.indexOf('--types') > -1) !== undefined;
 
+const skipInternal = process.argv.find((arg) => arg.indexOf('--skipInternal') > -1) !== undefined;
+
 const noEmoji = process.argv.find((arg) => arg.indexOf('--noemoji') > -1) !== undefined;
 
 if (!inputFiles || inputFiles.length === 0) {
@@ -56,7 +59,8 @@ generateDocumentation({
         url: repoUrl
       }
     }),
-    ...(types && {types})
+    ...(types && {types}),
+    ...(skipInternal && {skipInternal})
   },
   markdownOptions: {
     ...(noEmoji && {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,7 @@ import tseslint from 'typescript-eslint';
 
 export default [
   {
-    ignores: ['dist', '**/mock.ts', 'bin/index.js', 'jest.config.js', '**/*.spec.ts']
+    ignores: ['dist', '**/mock*.ts', 'bin/index.js', 'jest.config.js', '**/*.spec.ts']
   },
   {
     ...love,
@@ -35,6 +35,7 @@ export default [
   {
     rules: {
       complexity: 'off',
+      'max-lines': 'off',
       '@typescript-eslint/naming-convention': 'off',
       '@typescript-eslint/no-magic-numbers': 'off',
       '@typescript-eslint/no-unsafe-type-assertion': 'off',

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "format:check": "prettier --check .",
     "lint": "eslint --max-warnings 0 .",
     "build": "node rmdir.mjs && node esbuild.mjs && npm run ts-declaration",
+    "prepare": "npm run build",
     "contributors:add": "all-contributors add",
     "contributors:check": "all-contributors check",
     "contributors:generate": "all-contributors generate",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsdoc-markdown",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Generates markdown documentation from TypeScript source code.",
   "author": "David Dal Busco",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "tsdoc-parser"
   ],
   "peerDependencies": {
-    "typescript": "^5"
+    "typescript": "^5 || ^6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,6 @@
     "tsdoc-parser"
   ],
   "peerDependencies": {
-    "typescript": "^5 || ^6"
+    "typescript": "^5"
   }
 }

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -54,30 +54,44 @@ const serializeSymbol = ({
   ...(doc_type !== undefined && {doc_type})
 });
 
+const isInternal = (symbol: TypeScriptSymbol | undefined): boolean =>
+  symbol?.getJsDocTags().some(({name}) => name === 'internal') ?? false;
+
 const serializeEnum = ({
   checker,
   symbol,
-  doc_type
+  doc_type,
+  skipInternal
 }: {
   checker: TypeChecker;
   symbol: TypeScriptSymbol;
   doc_type?: DocEntryType;
+  skipInternal?: boolean;
 }): DocEntry => {
   const {members} = symbol.valueDeclaration as EnumDeclaration;
 
-  const properties: DocEntry[] = members.map((member) => {
-    const documentation = displayPartsToString(
-      (member as unknown as {symbol: TypeScriptSymbol}).symbol.getDocumentationComment(checker)
-    );
+  const properties: DocEntry[] = members
+    .filter((member) => {
+      if (!skipInternal) {
+        return true;
+      }
 
-    const type = member.initializer?.getText();
+      const {symbol} = member as unknown as {symbol: TypeScriptSymbol};
+      return !isInternal(symbol);
+    })
+    .map((member) => {
+      const documentation = displayPartsToString(
+        (member as unknown as {symbol: TypeScriptSymbol}).symbol.getDocumentationComment(checker)
+      );
 
-    return {
-      name: member.name.getText(),
-      ...(type !== undefined && {type}),
-      ...(documentation !== '' && {documentation})
-    };
-  });
+      const type = member.initializer?.getText();
+
+      return {
+        name: member.name.getText(),
+        ...(type !== undefined && {type}),
+        ...(documentation !== '' && {documentation})
+      };
+    });
 
   return {
     name: symbol.getName(),
@@ -91,10 +105,12 @@ const serializeEnum = ({
 /** Serialize a class symbol information */
 const serializeClass = ({
   checker,
-  symbol
+  symbol,
+  skipInternal
 }: {
   checker: TypeChecker;
   symbol: TypeScriptSymbol;
+  skipInternal?: boolean;
 }): DocEntry => {
   const details = serializeSymbol({checker, symbol, doc_type: 'class'});
 
@@ -103,6 +119,13 @@ const serializeClass = ({
 
   details.constructors = constructorType
     .getConstructSignatures()
+    .filter((signature: Signature) => {
+      if (!skipInternal) {
+        return true;
+      }
+
+      return !signature.getJsDocTags().some(({name}) => name === 'internal');
+    })
     .map((signature: Signature) => serializeSignature({checker, signature}))
     .filter(({documentation}) => documentation !== undefined && documentation !== '');
 
@@ -263,9 +286,10 @@ const visit = ({
   checker,
   node,
   types,
+  skipInternal,
   ...rest
 }: {checker: TypeChecker; node: Node} & Source &
-  Required<Pick<BuildOptions, 'types'>>): DocEntry[] => {
+  Required<Pick<BuildOptions, 'types' | 'skipInternal'>>): DocEntry[] => {
   // // Only consider exported nodes
   if (!isNodeExportedOrPublic(node)) {
     return [];
@@ -297,9 +321,13 @@ const visit = ({
       return;
     }
 
+    if (skipInternal && isInternal(symbol)) {
+      return;
+    }
+
     const details = {
       ...serializeSymbol({checker, symbol, doc_type}),
-      isStatic
+      ...(isStatic !== undefined && {isStatic})
     };
 
     pushEntry({node, details});
@@ -310,8 +338,12 @@ const visit = ({
     const symbol = checker.getSymbolAtLocation(node.name);
 
     if (symbol) {
+      if (skipInternal && isInternal(symbol)) {
+        return [];
+      }
+
       const classEntry: DocEntry = {
-        ...serializeClass({checker, symbol}),
+        ...serializeClass({checker, symbol, skipInternal}),
         methods: [],
         properties: [],
         jsDocs: symbol.getJsDocTags(),
@@ -322,7 +354,7 @@ const visit = ({
       };
 
       const visitChild = (node: Node): void => {
-        const docEntries: DocEntry[] = visit({node, checker, types, ...rest});
+        const docEntries: DocEntry[] = visit({node, checker, types, skipInternal, ...rest});
 
         // We do not need to repeat the file name for class members
 
@@ -345,7 +377,7 @@ const visit = ({
     }
   } else if (isModuleDeclaration(node)) {
     const visitChild = (node: Node): void => {
-      const docEntries: DocEntry[] = visit({node, checker, types, ...rest});
+      const docEntries: DocEntry[] = visit({node, checker, types, skipInternal, ...rest});
       entries.push(...docEntries);
     };
 
@@ -369,6 +401,10 @@ const visit = ({
         : undefined;
 
     if (arrowFunc !== undefined && arrowFuncSymbol !== undefined) {
+      if (skipInternal && isInternal(arrowFuncSymbol)) {
+        return [];
+      }
+
       const parentName = !isRootOrClassLevelArrowFunction(arrowFunc)
         ? getRootParentName(arrowFunc)
         : undefined;
@@ -403,6 +439,10 @@ const visit = ({
       const symbol = checker.getSymbolAtLocation(node.name);
 
       if (symbol) {
+        if (skipInternal && isInternal(symbol)) {
+          return [];
+        }
+
         const members = node.members
           .filter(
             (member) =>
@@ -410,6 +450,13 @@ const visit = ({
           )
           .map((member) => checker.getSymbolAtLocation(member.name!))
           .filter((symbol) => symbol !== undefined)
+          .filter((symbol) => {
+            if (!skipInternal) {
+              return true;
+            }
+
+            return !isInternal(symbol);
+          })
           .map((symbol) => serializeSymbol({checker, symbol: symbol!}));
 
         const interfaceEntry: DocEntry = {
@@ -427,6 +474,10 @@ const visit = ({
       const symbol = checker.getSymbolAtLocation(node.name);
 
       if (symbol) {
+        if (skipInternal && isInternal(symbol)) {
+          return [];
+        }
+
         const child = node.getChildren().find(({kind}) => isTypeKind(kind));
 
         const typeEntry: DocEntry = {
@@ -442,7 +493,11 @@ const visit = ({
       }
     } else if (isEnumDeclaration(node)) {
       const symbol = checker.getSymbolAtLocation(node.name)!;
-      const details = serializeEnum({checker, symbol});
+      if (skipInternal && isInternal(symbol)) {
+        return [];
+      }
+
+      const details = serializeEnum({checker, symbol, skipInternal});
       pushEntry({node, details});
     }
   }
@@ -505,15 +560,18 @@ export const buildDocumentation = ({
     compilerOptions,
     explore: userExplore,
     repo,
-    types: userTypes
+    types: userTypes,
+    skipInternal: userSkipInternal
   } = options ?? {
     explore: false,
     compilerOptions: DEFAULT_COMPILER_OPTIONS,
-    types: false
+    types: false,
+    skipInternal: false
   };
 
   const explore = userExplore ?? false;
   const types = userTypes ?? false;
+  const skipInternal = userSkipInternal ?? false;
 
   // Build a program using the set of root file names in fileNames
   const program = createProgram(inputFiles, compilerOptions ?? DEFAULT_COMPILER_OPTIONS);
@@ -537,7 +595,7 @@ export const buildDocumentation = ({
   for (const sourceFile of sourceFiles) {
     // Walk the tree to search for classes
     forEachChild(sourceFile, (node: Node) => {
-      const entries: DocEntry[] = visit({checker, node, sourceFile, repo, types});
+      const entries: DocEntry[] = visit({checker, node, sourceFile, repo, types, skipInternal});
       result.push(...entries);
     });
   }

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -327,7 +327,7 @@ const visit = ({
 
     const details = {
       ...serializeSymbol({checker, symbol, doc_type}),
-      ...(isStatic !== undefined && {isStatic})
+      isStatic
     };
 
     pushEntry({node, details});
@@ -450,13 +450,7 @@ const visit = ({
           )
           .map((member) => checker.getSymbolAtLocation(member.name!))
           .filter((symbol) => symbol !== undefined)
-          .filter((symbol) => {
-            if (!skipInternal) {
-              return true;
-            }
-
-            return !isInternal(symbol);
-          })
+          .filter((symbol) => !skipInternal || !isInternal(symbol))
           .map((symbol) => serializeSymbol({checker, symbol: symbol!}));
 
         const interfaceEntry: DocEntry = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -76,4 +76,6 @@ export interface BuildOptions {
   repo?: RepoOptions;
   // Documentation for Interfaces and Types is not generated per default. Set to true to include those.
   types?: boolean;
+  // If `true`, any documentation entry with an `@internal` JSDoc tag will be excluded.
+  skipInternal?: boolean;
 }

--- a/src/test/docs.spec.ts
+++ b/src/test/docs.spec.ts
@@ -30,4 +30,45 @@ describe('docs', () => {
       url: 'https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L6'
     });
   });
+
+  it('should skip internal entries', () => {
+    const doc = buildDocumentation({
+      inputFiles: ['./src/test/mock_internal.ts'],
+      options: {
+        types: true,
+        skipInternal: true
+      }
+    });
+
+    expect(doc.length).toBe(3);
+    expect(doc.map((e) => e.name)).toEqual(['visibleConst', 'VisibleClass', 'MixedEnum']);
+
+    const visibleClass = doc.find((e) => e.name === 'VisibleClass');
+    expect(visibleClass?.constructors).toEqual([]);
+    expect(visibleClass?.methods?.map((m) => m.name)).toEqual(['visibleMethod']);
+
+    const mixedEnum = doc.find((e) => e.name === 'MixedEnum');
+    expect(mixedEnum?.properties?.map((p) => p.name)).toEqual(['VISIBLE']);
+  });
+
+  it('should include internal entries by default', () => {
+    const doc = buildDocumentation({
+      inputFiles: ['./src/test/mock_internal.ts'],
+      options: {
+        types: true
+      }
+    });
+
+    expect(doc.map((e) => e.name)).toContain('internalConst');
+    expect(doc.map((e) => e.name)).toContain('InternalClass');
+    expect(doc.map((e) => e.name)).toContain('InternalInterface');
+    expect(doc.map((e) => e.name)).toContain('InternalType');
+
+    const visibleClass = doc.find((e) => e.name === 'VisibleClass');
+    expect(visibleClass?.constructors?.length).toBeGreaterThan(0);
+    expect(visibleClass?.methods?.map((m) => m.name)).toContain('internalMethod');
+
+    const mixedEnum = doc.find((e) => e.name === 'MixedEnum');
+    expect(mixedEnum?.properties?.map((p) => p.name)).toContain('INTERNAL');
+  });
 });

--- a/src/test/mock_internal.ts
+++ b/src/test/mock_internal.ts
@@ -1,0 +1,49 @@
+/**
+ * @internal
+ */
+export const internalConst = 'internal';
+
+/**
+ * Visible const
+ */
+export const visibleConst = 'visible';
+
+/**
+ * @internal
+ */
+export class InternalClass {}
+
+export class VisibleClass {
+  /**
+   * Internal constructor
+   * @internal
+   */
+  constructor() {}
+
+  /**
+   * @internal
+   */
+  internalMethod() {}
+
+  visibleMethod() {}
+}
+
+export enum MixedEnum {
+  /**
+   * @internal
+   */
+  INTERNAL = 'INTERNAL',
+  VISIBLE = 'VISIBLE'
+}
+
+/**
+ * @internal
+ */
+export interface InternalInterface {
+  prop: string;
+}
+
+/**
+ * @internal
+ */
+export type InternalType = string;


### PR DESCRIPTION
Hi! This is something I added for my own use; not sure if you're interested in having it upstream but I thought I'd ask.

It adds an argument `--skipInternal` to suppress doc outputs for any class/property/method with an `@internal` jsDoc tag. I only use the CLI, but it should also work for the code invocation.

Notes:
- I had to disable `max-lines` in eslint config, since the change bumped a file over the default file size limit. Since you had the `complexity` rule off I guessed you're ok with that.
- I also added a separate ts mock file to the tests, to avoid changing the main file you use.
- Bumped the TS peer dependency to `^5 || ^6`
- Add the `prepare` script so I could install from a GH branch. Feel free to remove if you'll merge this.

LMK any comments, cheers!